### PR TITLE
all: add Show Database statment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The goal of this project is largely inspired by [SerenityOS](https://serenityos.
   the [SQL-92 grammar](https://ronsavage.github.io/SQL/sql-92.bnf.html).
 - Typical SQL operations:
     - DQL & DML: `SELECT`, `DELETE`, `INSERT`, `UPDATE`
-    - DDL: `CREATE DATABASE`, `CREATE TABLE`
+    - DDL: `CREATE DATABASE`, `CREATE TABLE`, `SHOW DATABASE`
     - Joining: `LEFT JOIN`, `RIGHT JOIN`, `INNER JOIN`
     - Aggregation: `GROUP BY`, `COUNT(...)`, `AVG(...)`
     - Ordering & Limiting: `ORDER BY`, `LIMIT`

--- a/engine/session.go
+++ b/engine/session.go
@@ -54,6 +54,13 @@ func (s *Session) ExecQuery(q string) error {
 		}
 		fmt.Printf("selected database %s\n\r", stmt.DBName)
 		return nil
+	case sql.ShowDatabase:
+		rows, fields, err := EvaluateShowDatabase(stmt)
+		if err != nil {
+			return err
+		}
+		printTable(rows, fields)
+		return nil
 	}
 
 	if s.CurDB == "" {

--- a/engine/show.go
+++ b/engine/show.go
@@ -1,0 +1,10 @@
+package engine
+
+import (
+	"github.com/mk6i/mkdb/sql"
+	"github.com/mk6i/mkdb/storage"
+)
+
+func EvaluateShowDatabase(q sql.ShowDatabase) ([]*storage.Row, []*storage.Field, error) {
+	return storage.ShowDB()
+}

--- a/engine/show_test.go
+++ b/engine/show_test.go
@@ -1,0 +1,35 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/mk6i/mkdb/storage"
+)
+
+func TestShowDatabase(t *testing.T) {
+	defer storage.ClearDataDir()
+	s := Session{}
+	cases := []struct {
+		q    string
+		gold string
+	}{
+		{"SHOW DATABASE", "0 Result"},
+		{"SHOW DATABASES", "0 Result"},
+	}
+	for _, c := range cases {
+		if err := s.ExecQuery(c.q); err != nil {
+			t.Errorf("error running query:\n %s\nError: %s", c.q, err.Error())
+		}
+	}
+	q := `CREATE DATABASE testshow`
+	err := s.ExecQuery(q)
+	if err != nil {
+		t.Error(q)
+	}
+	for _, c := range cases {
+		if err := s.ExecQuery(c.q); err != nil {
+			t.Errorf("error running query:\n %s\nError: %s", c.q, err.Error())
+		}
+	}
+
+}

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -220,6 +220,8 @@ type Parser struct {
 	TokenList
 }
 
+type ShowDatabase struct{}
+
 type CreateDatabase struct {
 	Name string
 }
@@ -292,9 +294,29 @@ func (p *Parser) Parse() (interface{}, error) {
 		return p.Use()
 	case DELETE:
 		return p.Delete()
+	case SHOW:
+		return p.Show()
 	default:
 		return nil, syntaxErr(cur)
 	}
+}
+
+func (p *Parser) Show() (interface{}, error) {
+	cur := p.Cur()
+	p.Advance()
+	switch cur.Type {
+	case DATABASE:
+		return p.ShowDatabase()
+	case IDENT:
+		if strings.ToLower(cur.Text) == "databases" {
+			return p.ShowDatabase()
+		}
+	}
+	return nil, syntaxErr(cur)
+}
+
+func (p *Parser) ShowDatabase() (ShowDatabase, error) {
+	return ShowDatabase{}, nil
 }
 
 func (p *Parser) Create() (interface{}, error) {

--- a/sql/scanner.go
+++ b/sql/scanner.go
@@ -72,6 +72,7 @@ const (
 	SELECT
 	SEMICOLON
 	SET
+	SHOW
 	SUM
 	T_BOOL
 	T_INT
@@ -163,6 +164,7 @@ var Tokens = map[TokenType]string{
 	SELECT:    "SELECT",
 	SEMICOLON: ";",
 	SET:       "SET",
+	SHOW:      "SHOW",
 	SUM:       "SUM",
 	T_BOOL:    "BOOLEAN",
 	T_INT:     "INT",

--- a/storage/relation.go
+++ b/storage/relation.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -322,6 +324,31 @@ func OpenRelation(dbName string, forceWALSync bool) (*RelationService, error) {
 		fs:  fs,
 		wal: wal,
 	}, nil
+}
+
+func ShowDB() ([]*Row, []*Field, error) {
+	fields := []*Field{
+		{"", "Name"},
+	}
+
+	_, err := os.Stat(dataPath)
+	if os.IsNotExist(err) {
+		return nil, fields, nil
+	}
+
+	dbs, err := listDBs()
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Strings(dbs)
+	rows := make([]*Row, len(dbs))
+	for i, db := range dbs {
+		rows[i] = &Row{
+			RowID: uint32(i),
+			Vals:  []interface{}{db},
+		}
+	}
+	return rows, fields, nil
 }
 
 func CreateDB(dbName string) error {


### PR DESCRIPTION
This PR adds `SHOW` statment that shows all database that existed datapath.
Note: `DATABASES` is an alias to `DATABASE`

Example:
```
SHOW DATABASES;

| [Name]                |
| -------------------- |
| testdb               |

1 result(s) returned
```